### PR TITLE
Auto-discover serial port

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ a super-basic terminal and some utilities for crow
 
 ## setup
 
-- tested only on linux (assumes crow on `/dev/ttyACM0`)
+- tested on linux & mac osx (attaches to first found crow port)
 - requires pyserial. install using `pip install pyserial`
+- requires readline. install using `pip install readline`
+- requires python 2.7+
 
 ## druid (REPL)
 
@@ -16,6 +18,9 @@ python druid.py
 - type q (enter) to quit.
 - crow response is printed after each command entered.
 - readline enabled (up arrow)
+- type r to send & run the lua script in `sketch.lua` immediately
+- type u to upload the script in `sketch.lua` to crow's internal flash memory
+- type p to print the script currently in crow's internal flash memory
 
 example:
 

--- a/druid.py
+++ b/druid.py
@@ -1,6 +1,5 @@
 import sys
 import serial
-import readline
 import serial.tools.list_ports
 
 def getLua():

--- a/druid.py
+++ b/druid.py
@@ -44,3 +44,5 @@ while cmd != "q":
   print(ser.read(1000000))
   cmd = raw_input("> ")
 
+ser.close()
+exit()

--- a/druid.py
+++ b/druid.py
@@ -1,6 +1,7 @@
 import sys
 import serial
 import readline
+import serial.tools.list_ports
 
 def getLua():
     script = ""
@@ -10,10 +11,19 @@ def getLua():
             script += line
     return script
 
+port = ""
+for item in serial.tools.list_ports.comports():
+    if item[1] == 'crow: telephone line':
+        port = item[0]
+
+if port == "":
+    print("can't find crow device")
+    exit()
+
 try:
-  ser = serial.Serial("/dev/ttyACM0",115200, timeout=0.1)
+  ser = serial.Serial(port,115200, timeout=0.1)
 except:
-  print("serial problem with /dev/ttyACM0")
+  print("can't open serial port")
   exit()
 
 cmd = ""

--- a/druid.py
+++ b/druid.py
@@ -1,6 +1,7 @@
 import sys
 import serial
 import serial.tools.list_ports
+import readline
 
 def getLua():
     script = ""


### PR DESCRIPTION
Using pyserial's `comports` function to grab available ports & matching on crow's identification string.
Tested working on linux & mac.

Removed `readline` as it was not being used & is not available on windows. That said, I see `can't find crow device` on windows, and promptly gave up.

Added the `ser.close()` at the end to make sure the script released the port on quitting (not sure if this is necessary).