### PR TITLE
Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ a super-basic terminal and some utilities for crow
 ## setup
 
 - tested on linux & mac osx (attaches to first found crow port)
-- requires pyserial. install using `pip install pyserial`
-- requires readline. install using `pip install readline`
 - requires python 2.7+
+- requires pyserial. install using `pip install pyserial`
+- optionally uses readline. install using `pip install readline` (mac / linux only)
 
 ## druid (REPL)
 

--- a/druid.py
+++ b/druid.py
@@ -16,7 +16,8 @@ def getLua():
 
 port = ""
 for item in serial.tools.list_ports.comports():
-    if item[1] == 'crow: telephone line':
+    print(item[2])
+    if "USB VID:PID=0483:5740" in item[2]:
         port = item[0]
 
 if port == "":

--- a/druid.py
+++ b/druid.py
@@ -16,7 +16,6 @@ def getLua():
 
 port = ""
 for item in serial.tools.list_ports.comports():
-    print(item[2])
     if "USB VID:PID=0483:5740" in item[2]:
         port = item[0]
 

--- a/druid.py
+++ b/druid.py
@@ -1,7 +1,10 @@
 import sys
 import serial
 import serial.tools.list_ports
-import readline
+try:
+    import readline
+except importError:
+    print("readline failed to import")
 
 def getLua():
     script = ""


### PR DESCRIPTION
Ahoy! Just figured out the conditional import thing (or rather, ignore failed import of readline), and the serial port discovery now works on windows too.